### PR TITLE
Heroku: Start app from Neutrino built artifacts

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: node .

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "build": "neutrino build",
     "start": "neutrino start",
+    "start:prod": "neutrino build && node .",
     "start:local": "BACKEND=http://localhost:3000 neutrino start",
     "lint": "neutrino lint",
     "heroku-postbuild": "neutrino build"
@@ -43,6 +44,6 @@
     "postcss-simple-extend": "^1.0.0",
     "postcss-simple-vars": "^3.0.0"
   },
-  "main": "index.js",
+  "main": "build/index.js",
   "repository": "git@github.com:mozilla/firefox-health-dashboard.git"
 }

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,8 @@ import { AppContainer } from 'react-hot-loader';
 import './index.css';
 import Routes from './routes';
 
+console.log(process.env.NODE_ENV);
+
 const root = document.getElementById('root');
 const load = () => render(
   (


### PR DESCRIPTION
Without a Procfile, Heroku would call `yarn start` which starts the process
with NODE_ENV=development