### PR TITLE
Issue #94 - Fix Quantum page crashing

### DIFF
--- a/src/components/graph-container.js
+++ b/src/components/graph-container.js
@@ -44,6 +44,10 @@ export default class GraphContainer extends React.Component {
   }
 
   parseData(data) {
+    if (data.length === 0) {
+      this.setState({ apiFailed: true });
+      return;
+    }
     const { checkStatus, keys, targetValue, targetLine } = this.props;
     const stateObj = { data: transformGraphData(keys, data) };
     if (checkStatus) {


### PR DESCRIPTION
Unfortunately, the quantum flow burn up API was returning an empty
array causing the GraphContainer to pass it down and that causing issues.

The API mentioned is this one:
https://firefox-health-backend.herokuapp.com/api/bz/burnup/?whiteboard=%5Bqf%3Ap1%5D%5Bqf%3Af61%5D

We should add error boundaries for widgets so the whole page does not get unmounted.

@sarah-clements I'm going to land this before you see it. Do you have any suggestions on other ways of fixing this? Or tests to be added? Or anything to be changed on the backend? Thanks!