### PR TITLE
Issue #106 - Wrap all components in generic error boundaries

### DIFF
--- a/src/android/android-index.js
+++ b/src/android/android-index.js
@@ -8,13 +8,9 @@ import cx from 'classnames';
 import Dashboard from '../dashboard';
 import GraphContainer from '../components/graph-container';
 import { klarTargets, graphProps } from './constants';
+import GenericErrorBoundary from '../components/genericErrorBoundary';
 
 export default class AndroidIndex extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {};
-  }
-
   render() {
     return (
       <Dashboard
@@ -23,96 +19,104 @@ export default class AndroidIndex extends React.Component {
         className={cx('summary')}
       >
         <div className='row'>
-          <GraphContainer
-            query={{ site: 'abcnews.go.com' }}
-            title='abcnews.go.com'
-            legend={graphProps.legend}
-            baselines={[{ value: klarTargets['abcnews.go.com'], label: '+20%' }]}
-            target={graphProps.target}
-            api={graphProps.api}
-            keys={graphProps.keys}
-            width={graphProps.width}
-            height={graphProps.height}
-            checkStatus
-            targetValue={klarTargets['abcnews.go.com']}
-            targetLine='klar'
-          />
-
-          <GraphContainer
-            query={{ site: 'wikia-fandom' }}
-            title='wikia/fandom'
-            legend={graphProps.legend}
-            baselines={[{ value: klarTargets['wikia-fandom'], label: '+20%' }]}
-            target={graphProps.target}
-            api={graphProps.api}
-            keys={graphProps.keys}
-            width={graphProps.width}
-            height={graphProps.height}
-            checkStatus
-            targetValue={klarTargets['wikia-fandom']}
-            targetLine='klar'
-          />
-
-          <GraphContainer
-            query={{ site: 'buzzfeed' }}
-            title='buzzfeed'
-            legend={graphProps.legend}
-            baselines={[{ value: klarTargets.buzzfeed, label: '+20%' }]}
-            target={graphProps.target}
-            api={graphProps.api}
-            keys={graphProps.keys}
-            width={graphProps.width}
-            height={graphProps.height}
-            checkStatus
-            targetValue={klarTargets.buzzfeed}
-            targetLine='klar'
-          />
+          <GenericErrorBoundary>
+            <GraphContainer
+              query={{ site: 'abcnews.go.com' }}
+              title='abcnews.go.com'
+              legend={graphProps.legend}
+              baselines={[{ value: klarTargets['abcnews.go.com'], label: '+20%' }]}
+              target={graphProps.target}
+              api={graphProps.api}
+              keys={graphProps.keys}
+              width={graphProps.width}
+              height={graphProps.height}
+              checkStatus
+              targetValue={klarTargets['abcnews.go.com']}
+              targetLine='klar'
+            />
+          </GenericErrorBoundary>
+          <GenericErrorBoundary>
+            <GraphContainer
+              query={{ site: 'wikia-fandom' }}
+              title='wikia/fandom'
+              legend={graphProps.legend}
+              baselines={[{ value: klarTargets['wikia-fandom'], label: '+20%' }]}
+              target={graphProps.target}
+              api={graphProps.api}
+              keys={graphProps.keys}
+              width={graphProps.width}
+              height={graphProps.height}
+              checkStatus
+              targetValue={klarTargets['wikia-fandom']}
+              targetLine='klar'
+            />
+          </GenericErrorBoundary>
+          <GenericErrorBoundary>
+            <GraphContainer
+              query={{ site: 'buzzfeed' }}
+              title='buzzfeed'
+              legend={graphProps.legend}
+              baselines={[{ value: klarTargets.buzzfeed, label: '+20%' }]}
+              target={graphProps.target}
+              api={graphProps.api}
+              keys={graphProps.keys}
+              width={graphProps.width}
+              height={graphProps.height}
+              checkStatus
+              targetValue={klarTargets.buzzfeed}
+              targetLine='klar'
+            />
+          </GenericErrorBoundary>
         </div>
         <div className='row'>
-          <GraphContainer
-            query={{ site: 'yelp.de' }}
-            title='yelp.de'
-            legend={graphProps.legend}
-            baselines={[{ value: klarTargets['yelp.de'], label: '+20%' }]}
-            target={graphProps.target}
-            api={graphProps.api}
-            keys={graphProps.keys}
-            width={graphProps.width}
-            height={graphProps.height}
-            checkStatus
-            targetValue={klarTargets['yelp.de']}
-            targetLine='klar'
-          />
-
-          <GraphContainer
-            query={{ site: 'eurosport.eu' }}
-            title='eurosport.eu'
-            legend={graphProps.legend}
-            baselines={[{ value: klarTargets['eurosport.eu'], label: '+20%' }]}
-            target={graphProps.target}
-            api={graphProps.api}
-            keys={graphProps.keys}
-            width={graphProps.width}
-            height={graphProps.height}
-            checkStatus
-            targetValue={klarTargets['eurosport.eu']}
-            targetLine='klar'
-          />
-
-          <GraphContainer
-            query={{ site: 'm.ranker.com' }}
-            title='m.ranker.com'
-            legend={graphProps.legend}
-            baselines={[{ value: klarTargets['m.ranker.com'], label: '+20%' }]}
-            target={graphProps.target}
-            api={graphProps.api}
-            keys={graphProps.keys}
-            width={graphProps.width}
-            height={graphProps.height}
-            checkStatus
-            targetValue={klarTargets['m.ranker.com']}
-            targetLine='klar'
-          />
+          <GenericErrorBoundary>
+            <GraphContainer
+              query={{ site: 'yelp.de' }}
+              title='yelp.de'
+              legend={graphProps.legend}
+              baselines={[{ value: klarTargets['yelp.de'], label: '+20%' }]}
+              target={graphProps.target}
+              api={graphProps.api}
+              keys={graphProps.keys}
+              width={graphProps.width}
+              height={graphProps.height}
+              checkStatus
+              targetValue={klarTargets['yelp.de']}
+              targetLine='klar'
+            />
+          </GenericErrorBoundary>
+          <GenericErrorBoundary>
+            <GraphContainer
+              query={{ site: 'eurosport.eu' }}
+              title='eurosport.eu'
+              legend={graphProps.legend}
+              baselines={[{ value: klarTargets['eurosport.eu'], label: '+20%' }]}
+              target={graphProps.target}
+              api={graphProps.api}
+              keys={graphProps.keys}
+              width={graphProps.width}
+              height={graphProps.height}
+              checkStatus
+              targetValue={klarTargets['eurosport.eu']}
+              targetLine='klar'
+            />
+          </GenericErrorBoundary>
+          <GenericErrorBoundary>
+            <GraphContainer
+              query={{ site: 'm.ranker.com' }}
+              title='m.ranker.com'
+              legend={graphProps.legend}
+              baselines={[{ value: klarTargets['m.ranker.com'], label: '+20%' }]}
+              target={graphProps.target}
+              api={graphProps.api}
+              keys={graphProps.keys}
+              width={graphProps.width}
+              height={graphProps.height}
+              checkStatus
+              targetValue={klarTargets['m.ranker.com']}
+              targetLine='klar'
+            />
+          </GenericErrorBoundary>
         </div>
       </Dashboard>
     );

--- a/src/components/criticalErrorMessage.jsx
+++ b/src/components/criticalErrorMessage.jsx
@@ -1,0 +1,12 @@
+const newIssue = 'https://github.com/mozilla/firefox-health-dashboard/issues/new';
+
+const CriticalErrorMessage = () => (
+  <p style={{ textAlign: 'center', fontSize: '1.5em' }}>
+    <span>There has been a critical error. We have reported it. If the issue is not fixed
+      within few hours please file an issue:</span>
+    <br />
+    <a href={newIssue} target="_blank" rel="noopener noreferrer">{newIssue}</a>
+  </p>
+);
+
+export default CriticalErrorMessage;

--- a/src/components/genericErrorBoundary.jsx
+++ b/src/components/genericErrorBoundary.jsx
@@ -1,0 +1,40 @@
+import Raven from 'raven-js';
+import { Component } from 'react';
+import PropTypes from 'prop-types';
+
+import CriticalErrorMessage from './criticalErrorMessage';
+
+export default class ErrorBoundary extends Component {
+  state = {
+    caughtBoundaryError: false,
+  }
+
+  componentDidCatch(error, info) {
+    this.setState({ caughtBoundaryError: true });
+    Raven.captureException(error);
+    Raven.captureMessage(info);
+  }
+
+  render() {
+    if (this.state.caughtBoundaryError) {
+      if (this.props.critical) {
+        return <CriticalErrorMessage />;
+      }
+      return (
+        <div>
+          <p style={{ color: 'black' }}>Oops; something went wrong</p>
+        </div>
+      );
+    }
+    // eslint-disable-next-line react/prop-types
+    return this.props.children;
+  }
+}
+
+ErrorBoundary.propTypes = {
+  critical: PropTypes.bool,
+};
+
+ErrorBoundary.defaultProps = {
+  critical: false,
+};

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ import Raven from 'raven-js';
 import { render } from 'react-dom';
 import { AppContainer } from 'react-hot-loader';
 import './index.css';
+import GenericErrorBoundary from './components/genericErrorBoundary';
 import Routes from './routes';
 
 if (process.env.NODE_ENV === 'production') {
@@ -12,7 +13,9 @@ const root = document.getElementById('root');
 const load = () => render(
   (
     <AppContainer>
-      <Routes />
+      <GenericErrorBoundary critical>
+        <Routes />
+      </GenericErrorBoundary>
     </AppContainer>
   ), root,
 );

--- a/src/quantum/index-32bit.js
+++ b/src/quantum/index-32bit.js
@@ -15,6 +15,7 @@ import { quantum32QueryParams, flowGraphProps, getBugUrl, statusLabels } from '.
 import GraphContainer from '../components/graph-container';
 import CONFIG from './config';
 import TargetStatus from './target-status';
+import wrapSectionComponentsWithErrorBoundaries from '../utils/componentEnhancers';
 
 // Before this date we had a Speedometer benchmark update
 // and that caused a baseline bump for all browsers
@@ -105,7 +106,7 @@ export default class QuantumIndex32 extends React.Component {
       />
     );
 
-    const sections = [
+    const sections = wrapSectionComponentsWithErrorBoundaries([
       {
         cssRowExtraClasses: 'generic-metrics-graphics',
         rows: [[
@@ -363,7 +364,7 @@ export default class QuantumIndex32 extends React.Component {
           ],
         ],
       },
-    ];
+    ]);
 
     let rowIdx = 0;
     const $content = sections.reduce((reduced, { title, rows, cssRowExtraClasses }, sectionId) => {

--- a/src/quantum/index-64bit.js
+++ b/src/quantum/index-64bit.js
@@ -15,6 +15,7 @@ import { quantum64QueryParams, flowGraphProps, getBugUrl, statusLabels } from '.
 import CONFIG from './config';
 import TargetStatus from './target-status';
 import GraphContainer from '../components/graph-container';
+import wrapSectionComponentsWithErrorBoundaries from '../utils/componentEnhancers';
 
 // Before this date we had a Speedometer benchmark update
 // and that caused a baseline bump for all browsers
@@ -104,7 +105,7 @@ export default class QuantumIndex64 extends React.Component {
       />
     );
 
-    const sections = [
+    const sections = wrapSectionComponentsWithErrorBoundaries([
       {
         cssRowExtraClasses: 'generic-metrics-graphics',
         rows: [[
@@ -371,7 +372,7 @@ export default class QuantumIndex64 extends React.Component {
           ],
         ],
       },
-    ];
+    ]);
 
     let rowIdx = 0;
     const $content = sections.reduce((reduced, { title, rows, cssRowExtraClasses }, sectionId) => {

--- a/src/utils/componentEnhancers.jsx
+++ b/src/utils/componentEnhancers.jsx
@@ -1,0 +1,12 @@
+import GenericErrorBoundary from '../components/genericErrorBoundary';
+
+const wrapSectionComponentsWithErrorBoundaries = (sections = []) => (
+  sections.map(section => ({
+    ...section,
+    rows: section.rows.map(row => row.map((component, index) => (
+      <GenericErrorBoundary key={index}>{component}</GenericErrorBoundary>
+    ))),
+  }))
+);
+
+export default wrapSectionComponentsWithErrorBoundaries;


### PR DESCRIPTION
This allows the UI to still be somewhat useful even if one component
produces an uncaught error.

You can test that this works by adding something that will throw an error in one of the components.
For instance insice of src/quantum/countdown.js I added the line `date.lenght();`.

I still have to give this one more pass to make sure *all* widgets are wrapped as well as the Android release criteria page.

@sarah-clements This is the PR about error boundaries I mentioned to you